### PR TITLE
Declare extension Android-compatible

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "jasonm23_google-home-web-hide-deactivated@gmail.com"
-    }
+    },
+    "gecko_android": {}
   },
   "permissions": ["activeTab"],
   "content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "google-home-web-hide-deactivated",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "In Google Home Web, this extension hides deactivated automations and the redundant fake 'Add +' button.  Localized for English and Czech.",
   "author": "Jason Milkins",
   "browser_specific_settings": {


### PR DESCRIPTION
The previous version 1.0.2 was Android-compatible and was listed in the Android extension library.

Probably with publishing changes with 1.1.0, it's not possible to install the extension on Firefox for Android.

This change declares a compatible extension in the manifest:

https://discourse.mozilla.org/t/our-android-compatible-extension-does-not-show-up-in-search-on-ff-for-android-why/126069/4

https://extensionworkshop.com/documentation/publish/version-compatibility/#browser-specific-settings

It can also be done manually after each release at the plugin admin dashboard.